### PR TITLE
Fix HashMap related flaky tests

### DIFF
--- a/src/main/java/com/intel/jndn/utils/client/impl/SegmentedDataStream.java
+++ b/src/main/java/com/intel/jndn/utils/client/impl/SegmentedDataStream.java
@@ -25,7 +25,7 @@ import net.named_data.jndn.OnTimeout;
 import net.named_data.jndn.encoding.EncodingException;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +50,7 @@ public class SegmentedDataStream implements DataStream {
   private final byte PARTITION_MARKER = 0x00;
   private volatile long current = -1;
   private volatile long end = Long.MAX_VALUE;
-  private final Map<Long, Data> packets = new HashMap<>();
+  private final Map<Long, Data> packets = new LinkedHashMap<>();
   private final List<Object> observers = new ArrayList<>();
   private Exception exception;
 


### PR DESCRIPTION
## Description
Two tests
```
com.intel.jndn.utils.client.impl.DefaultSegmentedClientTest#verifyThatSegmentsAreRetrievedOnlyOnce
com.intel.jndn.utils.client.impl.DefaultSegmentedClientTest#testGetSegmentsAsync
```
could fail under [NonDex](https://github.com/TestingResearchIllinois/NonDex) which detect flakiness under non-deterministic data structure usages.

## Reproduce
```sh
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex \
    -Dtest=com.intel.jndn.utils.client.impl.DefaultSegmentedClientTest#verifyThatSegmentsAreRetrievedOnlyOnce
```

The potential problem I am seeing is that `SegmentedDataStream.packets` [uses HashMap internally](https://github.com/intel/jndn-utils/blob/master/src/main/java/com/intel/jndn/utils/client/impl/SegmentedDataStream.java#L53). The test will assemble the stream which relies on converting `packets` to list/collection of values, where as the order of conversion could differ in different environment. 

**From [Oracle Java 8 Doc](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html)**
> This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.

## Proposal
I replaced `HashMap` with `LinkedHashMap` which has a property of predictable order. Please let me know if you have better ideas or any question!
